### PR TITLE
onnx run can now print intermediate values

### DIFF
--- a/Athos/ONNXCompiler/onnx_run.py
+++ b/Athos/ONNXCompiler/onnx_run.py
@@ -29,6 +29,7 @@ import onnxruntime
 import common
 import os, sys
 import onnx
+from onnx import helper
 
 # First read the ONNX file
 if (len(sys.argv) < 2):
@@ -38,16 +39,26 @@ file_name = sys.argv[1]
 file_path = 'models/' + file_name
 model_name = file_name[:-5] # name without the '.onnx' extension
 model = onnx.load(file_path)
+sess = onnxruntime.InferenceSession(file_path) 
 
-model.graph.input[0]
-
+# Generating input
 input_dims = common.proto_val_to_dimension_tuple(model.graph.input[0])
 x = numpy.random.random(input_dims)
 print('Generated random input of dimension ' + str(input_dims))
 np.save(model_name + '_input', x)
 x = x.astype(numpy.float32)
 
-sess = onnxruntime.InferenceSession('models/' + file_name) 
+if (len(sys.argv) > 2):
+	intermediate_layer_value_info = helper.ValueInfoProto()
+	intermediate_layer_value_info.name = sys.argv[2]
+	model.graph.output.extend([intermediate_layer_value_info])
+	onnx.save(model, file_path + '_1')
+	sess = onnxruntime.InferenceSession(file_path + '_1') 
+	pred = sess.run([intermediate_layer_value_info.name], {'data': x})
+	np.save(model_name + '_debug', pred)
+	print("Saving the onnx runtime intermediate output for " + intermediate_layer_value_info.name)
+	exit() 
+
 pred = sess.run(None, {'data': x})
 np.save(model_name + '_output', pred)
 output_dims = common.proto_val_to_dimension_tuple(model.graph.output[0])


### PR DESCRIPTION
onnx run can now print intermediate values:
- Just feed the intermediate onnx node name to the `onnx_run.py`
e.g. `python3 onnx_run.py resnet18v2.onnx resnetv22_batchnorm2_fwd`