### PR TITLE
Simplified debugging by logging onnx output and cpp output for onnx node

### DIFF
--- a/Athos/ONNXCompiler/common.py
+++ b/Athos/ONNXCompiler/common.py
@@ -38,6 +38,12 @@ def numpy_float_array_to_fixed_point_val_str(input_array, scale):
 		cnt += 1
 	return (chunk, cnt)	
 
+def numpy_float_array_to_float_val_str(input_array):
+	chunk = ''
+	for val in numpy.nditer(input_array):
+		chunk += str(val) + '\n'
+	return chunk		
+
 def write_debug_info(node_name_to_out_var_dict):
 	if not os.path.exists('debug'):
 		os.makedirs('debug')	
@@ -55,4 +61,19 @@ def merge_name_map():
 
 	with open('debug/onnx_ezpc_name_map.txt', 'w') as f:
 		for val in onnx_seedot_name_map:
-			f.write(val + '   ' + seedot_ezpc_name_map[onnx_seedot_name_map[val]])			
+			f.write(val + '   ' + seedot_ezpc_name_map[onnx_seedot_name_map[val]])	
+
+def get_seedot_name_from_onnx_name(onnx_name):
+	onnx_seedot_name_map = pickle.load(open('debug/onnx_seedot_name_map.pkl', 'rb'))
+	print(onnx_seedot_name_map[onnx_name])
+
+def parse_output(scale):
+	f = open('debug/cpp_output_raw.txt', 'r')
+	g = open('debug/cpp_output.txt', 'w')
+	chunk = ''
+	for line in f:	
+		if line.rstrip().replace('-','0').isdigit():
+			val = float(line.rstrip())
+			val = val/(2**scale)
+			chunk += str(val) + '\n' 
+	g.write(chunk)		

--- a/Athos/ONNXCompiler/onnx_run.py
+++ b/Athos/ONNXCompiler/onnx_run.py
@@ -56,10 +56,14 @@ if (len(sys.argv) > 2):
 	sess = onnxruntime.InferenceSession(file_path + '_1') 
 	pred = sess.run([intermediate_layer_value_info.name], {'data': x})
 	np.save(model_name + '_debug', pred)
+	with open('debug/'+ model_name + '_onnx_debug.txt', 'w') as f:
+		f.write(common.numpy_float_array_to_float_val_str(pred))
 	print("Saving the onnx runtime intermediate output for " + intermediate_layer_value_info.name)
 	exit() 
 
 pred = sess.run(None, {'data': x})
 np.save(model_name + '_output', pred)
+with open('debug/'+ model_name + '_onnx_output.txt', 'w') as f:
+		f.write(common.numpy_float_array_to_float_val_str(pred))
 output_dims = common.proto_val_to_dimension_tuple(model.graph.output[0])
 print("Saving the onnx runtime output of dimension " + str(output_dims))

--- a/Athos/SeeDot/Codegen/EzPC.py
+++ b/Athos/SeeDot/Codegen/EzPC.py
@@ -30,10 +30,11 @@ import IR.IRUtil as IRUtil
 from Codegen.CodegenBase import CodegenBase
 
 class EzPC(CodegenBase):
-	def __init__(self, writer, decls):
+	def __init__(self, writer, decls, debugVar):
 		self.out = writer
 		self.decls = decls
 		self.consSFUsed = Util.Config.consSF
+		self.debugVar = debugVar
 
 	def printAll(self, prog:IR.Prog, expr:IR.Expr):
 		self._out_prefix()
@@ -128,7 +129,10 @@ class EzPC(CodegenBase):
 		self.out.printf('\n')
 
 	def _out_suffix(self, expr:IR.Expr):
-		self.out.printf('output(SERVER, ' + expr.idf + ');\n', indent=True)
+		if self.debugVar is None:
+			self.out.printf('output(SERVER, ' + expr.idf + ');\n', indent=True)
+		else:
+			self.out.printf('output(SERVER, ' + self.debugVar + ');\n', indent=True)
 		self.out.decreaseIndent()
 		self.out.printf('}\n', indent=True)
 	

--- a/Athos/SeeDot/Compiler.py
+++ b/Athos/SeeDot/Compiler.py
@@ -40,7 +40,7 @@ import Optimizations.LivenessOpti as LivenessOpti
 
 class Compiler:
 	def __init__(self, version, target, sfType, astFile, printASTBool, consSF, bitlen, outputFileName,
-				disableRMO, disableLivenessOpti, disableAllOpti):
+				disableRMO, disableLivenessOpti, disableAllOpti, debugVar):
 		assert(version == Util.Version.Fixed)
 		assert(target == Util.Target.EzPC)
 		assert(sfType == Util.SFType.Constant)
@@ -60,6 +60,7 @@ class Compiler:
 		Util.Config.disableRMO = disableRMO
 		Util.Config.disableLivenessOpti = disableLivenessOpti
 		Util.Config.disableAllOpti = disableAllOpti
+		Util.Config.debugVar = debugVar
 	
 	def insertStartEndFunctionCalls(self, res:(IR.Prog, IR.Expr)):
 		prog = res[0]
@@ -106,8 +107,10 @@ class Compiler:
 
 		writer = Writer(Util.Config.outputFileName)
 
+		debugVarEzPCName = compiler.name_mapping[Util.Config.debugVar] if (Util.Config.debugVar in compiler.name_mapping) else None  
+
 		if Util.forEzPC():
-			codegen = EzPCCodegen(writer, compiler.decls)
+			codegen = EzPCCodegen(writer, compiler.decls,  debugVarEzPCName)
 		else:
 			assert False
 

--- a/Athos/SeeDot/SeeDot.py
+++ b/Athos/SeeDot/SeeDot.py
@@ -42,6 +42,7 @@ class MainDriver:
 		parser.add_argument("--disableLivenessOpti", default=False, type=bool, help="Disable liveness optimization.")
 		parser.add_argument("--disableAllOpti", default=False, type=bool, help="Disable all optimizations.")
 		parser.add_argument("--outputFileName", help="Name of the output file with extension (Donot include folder path).")
+		parser.add_argument("--debugVar", help="Name of the onnx node to be debugged")
 		
 		self.args = parser.parse_args()
 
@@ -67,7 +68,8 @@ class MainDriver:
 					   self.args.outputFileName,
 					   self.args.disableRMO,
 					   self.args.disableLivenessOpti,
-					   self.args.disableAllOpti
+					   self.args.disableAllOpti,
+					   self.args.debugVar
 					   )
 		obj.run()
 

--- a/Athos/SeeDot/Util.py
+++ b/Athos/SeeDot/Util.py
@@ -52,6 +52,7 @@ class Config:
 	disableRMO = None
 	disableLivenessOpti = None
 	disableAllOpti = None
+	debugOnnx = None
 
 ###### Helper functions ######
 def loadASTFromFile():


### PR DESCRIPTION
Simplified debugging by logging onnx output and cpp output for selected onnx node

One command `./compile.sh resnet18v2.onnx BatchNorm17`

At the end of `BathcNorm17` operation the onnx value is stored in `debug/resnet18v2_onnx_debug.txt` and the cpp output after same node is logged in `debug/cpp_output.txt`

