### PR TITLE
Conv2DTranspose test passing

### DIFF
--- a/Athos/ONNXCompiler/onnx_run_tf.py
+++ b/Athos/ONNXCompiler/onnx_run_tf.py
@@ -47,7 +47,7 @@ def main():
 	model = onnx.load(file_path)
 	model = preprocess_for_tf(model)
 
-	x = np.load(model_name + '_input.npy')
+	x = np.load('debug/' + model_name + '/' + model_name + '_input.npy')
 	x = x.astype(np.float32)
 
 	input_name = model.graph.input[0].name
@@ -60,7 +60,7 @@ def main():
 		model.graph.output.extend([intermediate_layer_value_info])
 		output = prepare(model).run(x) 
 		pred = getattr(output, intermediate_layer_value_info_name)
-		np.save(model_name + '_debug', pred)
+		np.save('debug/' + model_name + '/' + model_name + '_debug', pred)
 		with open('debug/onnx_debug.txt', 'w') as f:
 			f.write(common.numpy_float_array_to_float_val_str(pred))
 		print("Saving the onnx runtime intermediate output for " + intermediate_layer_value_info.name)
@@ -68,7 +68,7 @@ def main():
 
 	output = prepare(model).run(x) 
 	pred = getattr(output, output_name)
-	np.save(model_name + '_output', pred)
+	np.save('debug/' + model_name + '/' + model_name + '_output', pred)
 	with open('debug/onnx_output.txt', 'w') as f:
 			f.write(common.numpy_float_array_to_float_val_str(pred))
 	output_dims = common.proto_val_to_dimension_tuple(model.graph.output[0])

--- a/Athos/SeeDot/IR/IRBuilderCSF.py
+++ b/Athos/SeeDot/IR/IRBuilderCSF.py
@@ -716,14 +716,14 @@ class IRBuilderCSF(ASTVisitor):
 			convDim = node.options[AST.PaddingKeysDict.ConvDim]
 
 		if convDim==2:
-			[N, H_prime, W_prime, CO1] = node.expr1.type.shape
-			[FH, FW, CI, CO] = node.expr2.type.shape
+			[N, H_prime, W_prime, CI1] = node.expr1.type.shape
+			[FH, FW, CO, CI] = node.expr2.type.shape
 		elif convDim==3:
-			[N, D_prime, H_prime, W_prime, CO1] = node.expr1.type.shape
-			[FD, FH, FW, CI, CO] = node.expr2.type.shape
+			[N, D_prime, H_prime, W_prime, CI1] = node.expr1.type.shape
+			[FD, FH, FW, CO, CI] = node.expr2.type.shape
 		else:
 			assert(False)
-		assert(CO1 == CO)
+		assert(CI1 == CI)
 		
 		H = node.options[AST.PaddingKeysDict.outputImgH] #outputH
 		W = node.options[AST.PaddingKeysDict.outputImgW] #outputW
@@ -756,12 +756,12 @@ class IRBuilderCSF(ASTVisitor):
 			funcCallArgsDict[IR.Int(D_prime, 32)] = "D_prime"
 		funcCallArgsDict[IR.Int(H_prime, 32)] = "H_prime"
 		funcCallArgsDict[IR.Int(W_prime, 32)] = "W_prime"
-		funcCallArgsDict[IR.Int(CO, 32)] = "CO"
+		funcCallArgsDict[IR.Int(CI, 32)] = "CI"
 		if convDim==3:
 			funcCallArgsDict[IR.Int(FD, 32)] = "FD"
 		funcCallArgsDict[IR.Int(FH, 32)] = "FH"
 		funcCallArgsDict[IR.Int(FW, 32)] = "FW"
-		funcCallArgsDict[IR.Int(CI, 32)] = "CI"
+		funcCallArgsDict[IR.Int(CO, 32)] = "CO"
 		if convDim==3:
 			funcCallArgsDict[IR.Int(D, 32)] = "D"
 		funcCallArgsDict[IR.Int(H, 32)] = "H"

--- a/Athos/SeeDot/Type.py
+++ b/Athos/SeeDot/Type.py
@@ -306,23 +306,23 @@ class InferType(ASTVisitor):
 			convDim = node.options[AST.PaddingKeysDict.ConvDim]
 
 		if convDim==2:
-			[N, HP, WP, CO1] = eType.shape
-			[FH, FW, CI, CO] = fType.shape
+			[N, HP, WP, CI1] = eType.shape
+			[FH, FW, CO, CI] = fType.shape
 		elif convDim==3:
-			[N, DP, HP, WP, CO1] = eType.shape
-			[FD, FH, FW, CI, CO] = fType.shape
+			[N, DP, HP, WP, CI1] = eType.shape
+			[FD, FH, FW, CO, CI] = fType.shape
 		else:
 			assert(False)
-		assert(CO1 == CO)
+		assert(CI1 == CI)
 		if convDim==3:
 			outputImgD = node.options[AST.PaddingKeysDict.outputImgD]
 		outputImgH = node.options[AST.PaddingKeysDict.outputImgH]
 		outputImgW = node.options[AST.PaddingKeysDict.outputImgW]
 
 		if convDim==2:
-			shape = [N, outputImgH, outputImgW, CI]
+			shape = [N, outputImgH, outputImgW, CO]
 		else:
-			shape = [N, outputImgD, outputImgH, outputImgW, CI]
+			shape = [N, outputImgD, outputImgH, outputImgW, CO]
 
 		# Logic explanation:
 		#	ConvTranpose can be thought of as the inverse of some convolution for which it is doing the upsampling.

--- a/Athos/TFEzPCLibrary/Library64_common.ezpc
+++ b/Athos/TFEzPCLibrary/Library64_common.ezpc
@@ -621,34 +621,21 @@ def void Squeeze24(int32_pl s1, int32_pl s2, int32_pl dim1, int32_pl dim2, int32
 (**************************)
 (* Generic implementation of ConvTranpose2D *)
 
-def void ConvTranspose2DReshapeFilter(int32_pl FH, int32_pl FW, int32_pl CI, int32_pl CO, int64_al[FH][FW][CI][CO] inputArr, int64_al[CI][FH*FW*CO] outputArr)
+def void ConvTranspose2DReshapeFilter(int32_pl FH, int32_pl FW, int32_pl CO, int32_pl CI, int64_al[FH][FW][CO][CI] inputArr, int64_al[CO][FH*FW*CI] outputArr)
 {
-	for ci=[0:CI]{
+	for co=[0:CO]{
 		for fh=[0:FH]{
 			for fw=[0:FW]{
-				for co=[0:CO]{
-					int32_pl linIdx = (fh*FW*CO) + (fw*CO) + co;
-					outputArr[ci][linIdx] = inputArr[fh][fw][ci][co];
+				for ci=[0:CI]{
+					int32_pl linIdx = (fh*FW*CI) + (fw*CI) + ci;
+					outputArr[co][linIdx] = inputArr[FH-1-fh][FW-1-fw][co][ci];
 				};
 			};
 		};
 	};
 }
 
-def void ConvTranspose2DReshapeMatMulOP(int32_pl N, int32_pl H, int32_pl W, int32_pl CI, int64_al[CI][N*H*W] inputArr, int64_al[N][H][W][CI] outputArr)
-{
-	for ci=[0:CI]{
-		for n=[0:N]{
-			for h=[0:H]{
-				for w=[0:W]{
-					outputArr[n][h][w][ci] = inputArr[ci][(n*H*W) + (h*W) + w];
-				};
-			};
-		};
-	};
-}
-
-def void ConvTranspose2DReshapeInput(int32_pl N, int32_pl HPrime, int32_pl WPrime, int32_pl CO, int32_pl FH, int32_pl FW, int32_pl zPadTrHLeft, int32_pl zPadTrHRight, int32_pl zPadTrWLeft, int32_pl zPadTrWRight, int32_pl strideH, int32_pl strideW, int32_pl RRows, int32_pl RCols, int64_al[N][HPrime][WPrime][CO] inputArr, int64_al[RRows][RCols] outputArr){
+def void ConvTranspose2DReshapeInput(int32_pl N, int32_pl HPrime, int32_pl WPrime, int32_pl CI, int32_pl FH, int32_pl FW, int32_pl zPadTrHLeft, int32_pl zPadTrHRight, int32_pl zPadTrWLeft, int32_pl zPadTrWRight, int32_pl strideH, int32_pl strideW, int32_pl RRows, int32_pl RCols, int64_al[N][HPrime][WPrime][CI] inputArr, int64_al[RRows][RCols] outputArr){
 	int32_pl linIdxFilterMult = 0;
 	for n=[0:N]{
 		int32_pl leftTopCornerH = 0 - zPadTrHLeft;
@@ -665,7 +652,7 @@ def void ConvTranspose2DReshapeInput(int32_pl N, int32_pl HPrime, int32_pl WPrim
 						int32_pl curPosH = leftTopCornerH + fh;
 						int32_pl curPosW = leftTopCornerW + fw;
 						int64_al val = 0L;
-						for co=[0:CO]{
+						for ci=[0:CI]{
 							if ((((curPosH < 0) || (curPosH >= HPrimeTilde)) || ((curPosW < 0) || (curPosW >= WPrimeTilde)))){
 								val = 0L;
 							}
@@ -674,13 +661,13 @@ def void ConvTranspose2DReshapeInput(int32_pl N, int32_pl HPrime, int32_pl WPrim
 								if (((curPosH % strideH) == 0) && ((curPosW % strideW) == 0)) {
 									int32_pl idxInputH = curPosH / strideH;
 									int32_pl idxInputW = curPosW / strideW;
-									val = inputArr[n][idxInputH][idxInputW][co];
+									val = inputArr[n][idxInputH][idxInputW][ci];
 								}
 								else{
 									val = 0L; (* This represents fractional stride. *)
 								};
 							};
-							outputArr[(fh*FW*CO) + (fw*CO) + co][linIdxFilterMult] = val;
+							outputArr[(fh*FW*CI) + (fw*CI) + ci][linIdxFilterMult] = val;
 						};
 					};
 				};
@@ -694,35 +681,35 @@ def void ConvTranspose2DReshapeInput(int32_pl N, int32_pl HPrime, int32_pl WPrim
 	};
 }
 
-(* int64_al[N][HPrime][WPrime][CO] inputArr,
-   int64_al[FH][FW][CI][CO] filter,
-   int64_al[N][H][W][CI] outputArr
+(* int64_al[N][HPrime][WPrime][CI] inputArr,
+   int64_al[FH][FW][CO][CI] filter,
+   int64_al[N][H][W][CO] outputArr
 *)
-def void ConvTranspose2DCSF(int32_pl N, int32_pl HPrime, int32_pl WPrime, int32_pl CO, 
-				   int32_pl FH, int32_pl FW, int32_pl CI, 
+def void ConvTranspose2DCSF(int32_pl N, int32_pl HPrime, int32_pl WPrime, int32_pl CI, 
+				   int32_pl FH, int32_pl FW, int32_pl CO, 
 				   int32_pl H, int32_pl W,
 				   int32_pl zPadTrHLeft, int32_pl zPadTrHRight, int32_pl zPadTrWLeft, int32_pl zPadTrWRight, 
 				   int32_pl strideH, int32_pl strideW,
-				   int64_al[N][HPrime][WPrime][CO] inputArr, 
-				   int64_al[FH][FW][CI][CO] filterArr, 
+				   int64_al[N][HPrime][WPrime][CI] inputArr, 
+				   int64_al[FH][FW][CO][CI] filterArr, 
 				   int32_pl consSF,
-				   int64_al[N][H][W][CI] outArr)
+				   int64_al[N][H][W][CO] outArr)
 {
-	int32_pl reshapedFilterRows = CI;
-	int32_pl reshapedFilterCols = FH*FW*CO;
-	int32_pl reshapedIPRows = FH*FW*CO;
+	int32_pl reshapedFilterRows = CO;
+	int32_pl reshapedFilterCols = FH*FW*CI;
+	int32_pl reshapedIPRows = FH*FW*CI;
 	int32_pl reshapedIPCols = N * H * W;
 
 	int64_al[reshapedFilterRows][reshapedFilterCols] filterReshaped;
 	int64_al[reshapedIPRows][reshapedIPCols] inputReshaped;
 	int64_al[reshapedFilterRows][reshapedIPCols] matmulOP;
 
-	ConvTranspose2DReshapeFilter(FH, FW, CI, CO, filterArr, filterReshaped);
-	ConvTranspose2DReshapeInput(N, HPrime, WPrime, CO, FH, FW, zPadTrHLeft, zPadTrHRight, zPadTrWLeft, zPadTrWRight, strideH, strideW, reshapedIPRows, reshapedIPCols, inputArr, inputReshaped);
+	ConvTranspose2DReshapeFilter(FH, FW, CO, CI, filterArr, filterReshaped);
+	ConvTranspose2DReshapeInput(N, HPrime, WPrime, CI, FH, FW, zPadTrHLeft, zPadTrHRight, zPadTrWLeft, zPadTrWRight, strideH, strideW, reshapedIPRows, reshapedIPCols, inputArr, inputReshaped);
 
 	MatMulCSF2D(reshapedFilterRows, reshapedFilterCols, reshapedIPCols, filterReshaped, inputReshaped, matmulOP, consSF);
 
-	ConvTranspose2DReshapeMatMulOP(N, H, W, CI, matmulOP, outArr);
+	Conv2DReshapeMatMulOP(N, H, W, CO, matmulOP, outArr);
 }
 
 (**************************)


### PR DESCRIPTION
Removed a bug from `Conv2D` implementation
switched names `CI` and `CO`, according to the TF and ONNX convention

Test:
Run `python3 -m unittest -v test.test.TestNode.test_conv_transpose`

TODO: Repeat this for `Conv3DTranspose`