### PR TITLE
Add missing include of the `string` header to globals.h

### DIFF
--- a/SCI/src/globals.h
+++ b/SCI/src/globals.h
@@ -24,6 +24,7 @@ SOFTWARE.
 
 #include <cstdint> //Only keep standard headers over here
 #include <chrono>  //Keep the local repo based headers below, once constants are defined
+#include <string>
 #include <thread>
 #include <map>
 


### PR DESCRIPTION
This fixes a compilation problem because the `std::string` return type
of `get_network_label` was incomplete.

```
In file included from /path/to/EzPC/SCI/tests/test_field_maxpool.cpp:24:
/path/to/EzPC/SCI/src/globals.h:50:62: error: return type ‘std::string’ {aka ‘class std::__cxx11::basic_string<char>’} is incomplete
   50 | inline std::string get_network_label(NetworkName network_name) {
```