### PR TITLE
Resolving the [ABY] std::bad_alloc() error which was being encountered on running dot_product example

### DIFF
--- a/EzPC/EzPC/codegen.ml
+++ b/EzPC/EzPC/codegen.ml
@@ -739,7 +739,7 @@ e_role role;\n"
 
 let aby_main_prelude_string :string =
 "role = role_param;\n\
-party = new ABYParty(role_param, address, port, seclvl, bitlen, nthreads, mt_alg, 520000000);\n\
+party = new ABYParty(role_param, address, port, seclvl, bitlen, nthreads, mt_alg, 4000000);\n\
 std::vector<Sharing*>& sharings = party->GetSharings();\n\
 ycirc = (sharings)[S_YAO]->GetCircuitBuildRoutine();\n\
 acirc = (sharings)[S_ARITH]->GetCircuitBuildRoutine();\n\


### PR DESCRIPTION
The Pull Request fixes the **Issue: #107** 🚀

So when we were trying to compile the **dot_product.ezpc** file it generates the **dot_product0.cpp** file with the following command. `./ezpc.sh dot_product.ezpc --bitlen 32`
It was getting generated successfully but on the further compilation of EzPC with ABY through` ./compile_aby.sh dot_product0.cpp` it generates the binary file as **./dot_product0** and when we try to run this following binary with the following command - `./dot_product0` it gives us an error which has been described below.

**Error:**
```
terminate called after throwing an instance of 'std::bad_alloc'
  what():   std::bad_alloc
Aborted (core dumped)
```

**How to test:**

* Cloning this repository locally

* Compiling the EzPC file which will generate the **dot_product.cpp** file
```
./ezpc.sh dot_product.ezpc --bitlen 32
```

* So within the dot_product.cpp file. refer to the line no 377 which looks like the following 
```
party = new ABYParty(role_param, address, port, seclvl, bitlen, nthreads, mt_alg, 520000000);
```
Here to note that since this is doing a dynamic allocation so replace the above line with the following line:
```
ABYParty* party = new ABYParty(role_param, address, port, seclvl, bitlen, nthreads, mt_alg, 65536);
```

The reason to replace `520000000` with the `65536` is that within the **ABY Project** it has `reservegates` which has the default value of `65536`.
https://github.com/encryptogroup/ABY/blob/d8e69414d091cafc007e65a03ef30768ebaf723d/src/abycore/aby/abyparty.h#L43-L44

* Compiling the EzPC with the ABY
```
./compile_aby.sh dot_product0.cpp 
```

* Running the compiled file
```
./dot_product0 -r 0
```

Hence this successfully resolve this Issue. Thanks! 😀