### PR TITLE
Replace broken boost 1.67.0 download link in setup script

### DIFF
--- a/setup_env_and_build.sh
+++ b/setup_env_and_build.sh
@@ -126,7 +126,9 @@ python3 -m pip install onnx_graphsurgeon --index-url https://pypi.ngc.nvidia.com
 build_boost () {
   sudo apt-get -y install python3.7-dev autotools-dev libicu-dev libbz2-dev
   echo "Building and installing boost from source"
-  wget https://boostorg.jfrog.io/artifactory/main/release/1.67.0/source/boost_1_67_0.tar.gz
+  # jfrog no longer provides boost archive, use boost.io instead
+  # wget https://boostorg.jfrog.io/artifactory/main/release/1.67.0/source/boost_1_67_0.tar.gz
+  wget https://archives.boost.io/release/1.67.0/source/boost_1_67_0.tar.gz
   tar -zxvf boost_1_67_0.tar.gz
   cd boost_1_67_0
   ./bootstrap.sh

--- a/setup_env_and_build.sh
+++ b/setup_env_and_build.sh
@@ -126,8 +126,6 @@ python3 -m pip install onnx_graphsurgeon --index-url https://pypi.ngc.nvidia.com
 build_boost () {
   sudo apt-get -y install python3.7-dev autotools-dev libicu-dev libbz2-dev
   echo "Building and installing boost from source"
-  # jfrog no longer provides boost archive, use boost.io instead
-  # wget https://boostorg.jfrog.io/artifactory/main/release/1.67.0/source/boost_1_67_0.tar.gz
   wget https://archives.boost.io/release/1.67.0/source/boost_1_67_0.tar.gz
   tar -zxvf boost_1_67_0.tar.gz
   cd boost_1_67_0


### PR DESCRIPTION
The current download link for boost_1_67_0.tar.gz in the setup script is broken. It redirects to https://landing.jfrog.com/reactivate-server/boostorg, which appears to be a dead link or paywall, causing wget to download an HTML page instead of the expected archive, thereby stalling the installation process.

To resolve this issue, I have replaced the broken link with an alternative, functional link: https://archives.boost.io/release/1.67.0/source/boost_1_67_0.tar.gz